### PR TITLE
need to lock before wait.

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -541,8 +541,8 @@ PaError PaPulseAudio_StartStreamCb(
     {
         while (1)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
             pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
 
             if (stream->outStream != NULL)
             {


### PR DESCRIPTION
According to pulseaudio documentation needs to lock the main thread before wait. This makes this work in android / termux. 